### PR TITLE
Store test output to a temporary directory

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,10 +1,7 @@
 use ExtUtils::MakeMaker;
 
-#  make the samples directory
-mkdir ('samples', 00755);
-
 #  write the makefile
 WriteMakefile ( 'NAME' => 'Chart',
-		'PREREQ_PM' => { 'GD' => 2.0 },
+		'PREREQ_PM' => { 'GD' => 2.0, 'File::Temp' => 0.19 },
 		'dist' => { 'COMPRESS' => 'gzip', 'SUFFIX' => 'gz' },
 		'VERSION' => '2.400.1' )

--- a/t/Humidity.t
+++ b/t/Humidity.t
@@ -8,6 +8,8 @@ BEGIN { unshift @INC, 'lib', '../lib'}
 
 use strict;
 use Chart::Lines;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -228,12 +230,12 @@ $graphic->set( 'y_label' => $einheit );
 
 if ( $graphic->can('gif') )
 {
-    my $wettgif = "samples/" . $gif_name . ".gif";
+    my $wettgif = "$samples/" . $gif_name . ".gif";
     $graphic->gif($wettgif);
 }
 elsif ( $graphic->can('png') )
 {
-    my $wettgif = "samples/" . $gif_name . ".png";
+    my $wettgif = "$samples/" . $gif_name . ".png";
     $graphic->png($wettgif);
 }
 

--- a/t/Math_1_over_x.t
+++ b/t/Math_1_over_x.t
@@ -8,6 +8,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use strict;
 use Chart::Lines;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -85,12 +87,12 @@ $graphic->set( 'y_label'         => 'f = 1/x' );
 
 if ( $graphic->can('gif') )
 {
-    my $picture_file = "samples/Math_1_over_x.gif";
+    my $picture_file = "$samples/Math_1_over_x.gif";
     $graphic->gif($picture_file);
 }
 if ( $graphic->can('png') )
 {
-    my $picture_file = "samples/Math_1_over_x.png";
+    my $picture_file = "$samples/Math_1_over_x.png";
     $graphic->png($picture_file);
 }
 

--- a/t/bars.t
+++ b/t/bars.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Bars;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -44,7 +46,7 @@ $g->add_dataset( 50000, 70000, 20200,  80000.8, 40000 );
 );
 $g->set(%hash);
 
-$g->png("samples/bars.png");
+$g->png("$samples/bars.png");
 
 print "ok 1\n";
 

--- a/t/bars_10.t
+++ b/t/bars_10.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Bars;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -36,7 +38,7 @@ $g->add_dataset( 0, 0, 0, 0, 0 );
 
 $g->set(%hash);
 
-$g->png("samples/bars_10.png");
+$g->png("$samples/bars_10.png");
 
 print "ok 1\n";
 

--- a/t/bars_2.t
+++ b/t/bars_2.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 
 use Chart::Bars;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -46,7 +48,7 @@ $g->add_dataset( 17,       5,       7,      2,        6 );
 
 $g->set(%hash);
 
-$g->png("samples/bars_2.png");
+$g->png("$samples/bars_2.png");
 
 print "ok 1\n";
 

--- a/t/bars_3.t
+++ b/t/bars_3.t
@@ -4,6 +4,8 @@ BEGIN { unshift @INC, 'lib', '../lib'}
 
 
 use Chart::Bars;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 print "1..1\n";
 $g = Chart::Bars->new( 500, 500 );
 
@@ -29,7 +31,7 @@ $g->add_dataset( -2.4,   3.4,      1.9,      1.2,       -1.1,     -2.9 );
 );
 $g->set(%hash);
 
-$g->png("samples/bars_3.png");
+$g->png("$samples/bars_3.png");
 
 print "ok 1\n";
 

--- a/t/bars_4.t
+++ b/t/bars_4.t
@@ -6,6 +6,8 @@ BEGIN { unshift @INC, 'lib', '../lib'}
 
 use strict;
 use Chart::Bars;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -13,7 +15,7 @@ my @x_values = ();    # x axis
 my @y_values = ();
 
 my $graphic;
-my $picture_file = "samples/bars_4.png";
+my $picture_file = "$samples/bars_4.png";
 my $min_y        = -5;                     # max. y-values
 my $max_y        = 5;
 

--- a/t/bars_5.t
+++ b/t/bars_5.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use strict;
 use Chart::Bars;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -37,7 +39,7 @@ $g->add_dataset(@data);
 );
 
 $g->set(%hash);
-$g->png("samples/bars_5.png");
+$g->png("$samples/bars_5.png");
 print "ok 1\n";
 
 exit(0);

--- a/t/bars_6.t
+++ b/t/bars_6.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use strict;
 use Chart::Bars;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -42,7 +44,7 @@ $g->set(
     #    max_val            => 9000,
 );
 
-$g->png("samples/bars_6.png");
+$g->png("$samples/bars_6.png");
 print "ok 1\n";
 
 exit(0);

--- a/t/bars_7.t
+++ b/t/bars_7.t
@@ -4,6 +4,8 @@ BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Bars;
 use strict;
 use POSIX;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 my $a;
 
@@ -44,7 +46,7 @@ $g->set(
     x_label         => 'Date',
 );
 
-$g->png("samples/bars_7.png");
+$g->png("$samples/bars_7.png");
 print "ok 1\n";
 
 exit(0);

--- a/t/bars_8.t
+++ b/t/bars_8.t
@@ -4,6 +4,8 @@ BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Bars;
 use strict;
 use POSIX;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 my $a;
 $a = 10**(-30);
@@ -48,7 +50,7 @@ $g->set(
     x_label     => 'Date',
 );
 
-$g->png("samples/bars_8.png");
+$g->png("$samples/bars_8.png");
 print "ok 1\n";
 
 exit(0);

--- a/t/bars_9.t
+++ b/t/bars_9.t
@@ -4,6 +4,8 @@ BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Bars;
 use strict;
 use POSIX;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -40,7 +42,7 @@ $g->set(
     x_label        => 'Date',
 );
 
-$g->png("samples/bars_9.png");
+$g->png("$samples/bars_9.png");
 print "ok 1\n";
 
 exit(0);

--- a/t/composite.t
+++ b/t/composite.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Composite;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -31,7 +33,7 @@ $g->set(
     }
 );
 $g->set( 'brush_size2' => 1 );
-$g->png("samples/composite.png");
+$g->png("$samples/composite.png");
 
 print "ok 1\n";
 

--- a/t/composite_1.t
+++ b/t/composite_1.t
@@ -2,13 +2,15 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Composite;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 print "1..1\n";
 
 my $obj = Chart::Composite->new( 600, 500 );
 my @legend_ary;
 my ( $legend, @zeile );
 my @all_aryref;
-open( OUT, ">samples/composite_1.png" ) or die "cannot write file samples/composite_1.png\n";
+open( OUT, ">$samples/composite_1.png" ) or die "cannot write file $samples/composite_1.png\n";
 
 my $i       = 0;
 my $e       = 0;

--- a/t/composite_2.t
+++ b/t/composite_2.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use strict;
 use Chart::Composite;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -59,7 +61,7 @@ $g->set(
 
 $g->set( 'f_y_tick' => sub { return ( $_[0] . '(' . sprintf( "%.1f", $_[0] / 18.0182 ) . ')' ) } );
 
-$g->png("samples/composite_2.png");
+$g->png("$samples/composite_2.png");
 
 print "ok 1\n";
 

--- a/t/composite_3.t
+++ b/t/composite_3.t
@@ -3,13 +3,15 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use strict;
 use Chart::Composite;    #(type is one of: Points, Lines, Bars, LinesPoints, Composite, StackedBars, Mountain)
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 my $obj = Chart::Composite->new( 800, 600 );    #Breite, Höhe
 my @legend_ary;
 my ( $legend, @zeile );
 my @all_aryref;
-open( OUT, ">samples/composite_3.png" ) or die "kann Datei nicht schreiben\n";
+open( OUT, ">$samples/composite_3.png" ) or die "kann Datei nicht schreiben\n";
 
 my $i       = 0;
 my $e       = 0;

--- a/t/composite_4.t
+++ b/t/composite_4.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Composite;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -19,7 +21,7 @@ $g->set(
     'include_zero'   => 'true',
 );
 
-$g->png("samples/composite_4.png");
+$g->png("$samples/composite_4.png");
 
 print "ok 1\n";
 

--- a/t/composite_5.t
+++ b/t/composite_5.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Composite;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -18,7 +20,7 @@ $g->set(
     'composite_info' => [ [ 'Bars', [ 1 .. 3 ] ], [ 'LinesPoints', [4] ] ]
 );
 
-$g->png("samples/composite_5.png");
+$g->png("$samples/composite_5.png");
 
 print "ok 1\n";
 

--- a/t/composite_6.t
+++ b/t/composite_6.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Composite;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -34,7 +36,7 @@ my %chart_settings = (
 );
 
 $chart->set(%chart_settings);
-$chart->png("samples/composite_6.png");
+$chart->png("$samples/composite_6.png");
 
 print "ok 1\n";
 

--- a/t/composite_7.t
+++ b/t/composite_7.t
@@ -6,6 +6,8 @@ use Chart::Lines;
 use Chart::Points;
 use Chart::LinesPoints;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -47,7 +49,7 @@ $g->add_dataset( @x[@s] );
 $g->add_dataset( @y[@s] );
 $g->add_dataset(@x2);
 $g->set(%hash);
-$g->jpeg("samples/composite_7.jpg");
+$g->jpeg("$samples/composite_7.jpg");
 
 print "ok 1\n";
 

--- a/t/composite_8.t
+++ b/t/composite_8.t
@@ -11,6 +11,8 @@ use Chart::Lines;
 use Chart::Points;
 use Chart::LinesPoints;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -53,7 +55,7 @@ $g->add_dataset( @y[@s] );
 $g->add_dataset(@x2);
 $g->set(%hash);
 $g->set( xy_plot => 1 );
-$g->jpeg("samples/composite_8.jpg");
+$g->jpeg("$samples/composite_8.jpg");
 
 print "ok 1\n";
 

--- a/t/composite_f.t
+++ b/t/composite_f.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Composite;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -24,7 +26,7 @@ $g->set( 'legend_example_height0..1' => '10' );
 $g->set( 'legend_example_height2'    => '3' );
 $g->set( 'f_y_tick'                  => \&multiply );
 $g->set( 'f_x_tick'                  => \&int_quadrat );
-$g->png("samples/composite_f.png");
+$g->png("$samples/composite_f.png");
 
 print "ok 1\n";
 

--- a/t/direction_1.t
+++ b/t/direction_1.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Direction;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -23,7 +25,7 @@ $g->set(
     # 'polar' => 'true',
 );
 
-$g->png("samples/direction_1.png");
+$g->png("$samples/direction_1.png");
 
 print "ok 1\n";
 

--- a/t/direction_2.t
+++ b/t/direction_2.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Direction;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -21,7 +23,7 @@ $g->set(
 
 );
 
-$g->png("samples/direction_2.png");
+$g->png("$samples/direction_2.png");
 
 print "ok 1\n";
 

--- a/t/direction_3.t
+++ b/t/direction_3.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Direction;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -28,7 +30,7 @@ $g->set(
     'grey_background' => 'false',
 );
 
-$g->png("samples/direction_3.png");
+$g->png("$samples/direction_3.png");
 
 print "ok 1\n";
 

--- a/t/direction_4.t
+++ b/t/direction_4.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Direction;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -31,7 +33,7 @@ $g->set(
     'grey_background' => 'false',
 );
 
-$g->png("samples/direction_4.png");
+$g->png("$samples/direction_4.png");
 
 print "ok 1\n";
 

--- a/t/error_1.t
+++ b/t/error_1.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::ErrorBars;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -24,7 +26,7 @@ $g->set(
 
 );
 
-$g->png("samples/error_1.png");
+$g->png("$samples/error_1.png");
 
 print "ok 1\n";
 

--- a/t/error_2.t
+++ b/t/error_2.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::ErrorBars;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -24,7 +26,7 @@ $g->set(
     'custom_x_ticks' => [ 0, 1 ],
 );
 
-$g->png("samples/error_2.png");
+$g->png("$samples/error_2.png");
 
 print "ok 1\n";
 

--- a/t/f_ticks.t
+++ b/t/f_ticks.t
@@ -9,6 +9,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use strict;
 use Chart::Points;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -72,12 +74,12 @@ $graphic->set( 'f_y_tick' => \&formatter );
 
 if ( $graphic->can('gif') )
 {
-    my $picture_file = "samples/f_ticks.gif";
+    my $picture_file = "$samples/f_ticks.gif";
     $graphic->gif($picture_file);
 }
 if ( $graphic->can('png') )
 {
-    my $picture_file = "samples/f_ticks.png";
+    my $picture_file = "$samples/f_ticks.png";
     $graphic->png($picture_file);
 }
 

--- a/t/f_ticks_1.t
+++ b/t/f_ticks_1.t
@@ -7,6 +7,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use strict;
 use Chart::LinesPoints;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -93,7 +95,7 @@ $graphic->set( 'f_x_tick' => \&convert_to_real_x );
 
 if ( $graphic->can('png') )
 {
-    my $picture_file = "samples/f_ticks_1.png";
+    my $picture_file = "$samples/f_ticks_1.png";
     $graphic->png($picture_file);
 }
 

--- a/t/hbars_1.t
+++ b/t/hbars_1.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::HorizontalBars;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -40,7 +42,7 @@ $g->add_dataset( 5,  4,  2,  5,  3,  6,  1,  4,  5,  4,  2,  5 );
 
 $g->set(%hash);
 
-$g->png("samples/hbars_1.png");
+$g->png("$samples/hbars_1.png");
 
 print "ok 1\n";
 

--- a/t/hbars_2.t
+++ b/t/hbars_2.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::HorizontalBars;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -34,7 +36,7 @@ $g->add_dataset( 7,     -5,    -3,     4,      7 );
 
 $g->set(%hash);
 
-$g->png("samples/hbars_2.png");
+$g->png("$samples/hbars_2.png");
 
 print "ok 1\n";
 

--- a/t/hbars_3.t
+++ b/t/hbars_3.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::HorizontalBars;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -23,7 +25,7 @@ $g->add_dataset( -2,    -10,   -3,     -8,     -3 );
 
 $g->set(%hash);
 
-$g->png("samples/hbars_3.png");
+$g->png("$samples/hbars_3.png");
 
 print "ok 1\n";
 

--- a/t/hbars_4.t
+++ b/t/hbars_4.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::HorizontalBars;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -19,7 +21,7 @@ $g->add_dataset( 2,     10,    3,      8,      3 );
 );
 
 $g->set(%hash);
-$g->png("samples/hbars_4.png");
+$g->png("$samples/hbars_4.png");
 
 print "ok 1\n";
 exit(0);

--- a/t/lines.t
+++ b/t/lines.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Lines;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -22,7 +24,7 @@ $g->add_dataset( 5,     7,     2.3,    10,     12, );
     }
 );
 $g->set(%hash);
-$g->png("samples/lines.png");
+$g->png("$samples/lines.png");
 print "ok 1\n";
 
 #

--- a/t/lines_1.t
+++ b/t/lines_1.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Lines;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 my $g;
 
 print "1..1\n";
@@ -30,7 +32,7 @@ $g->set( 'y_label2'     => 'y label 2' );
 $g->set( 'y_grid_lines' => 'true' );
 $g->set( 'legend'       => 'bottom' );
 
-$g->png("samples/lines_1.png");
+$g->png("$samples/lines_1.png");
 
 print "ok 1\n";
 

--- a/t/lines_2.t
+++ b/t/lines_2.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Lines;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 my $g;
 
 print "1..1\n";
@@ -31,7 +33,7 @@ $g->set( 'y_label2'     => 'y label 2' );
 $g->set( 'y_grid_lines' => 'true' );
 $g->set( 'legend'       => 'left' );
 
-$g->png("samples/lines_2.png");
+$g->png("$samples/lines_2.png");
 
 print "ok 1\n";
 

--- a/t/lines_3.t
+++ b/t/lines_3.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Lines;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 my $g;
 
 print "1..1\n";
@@ -30,7 +32,7 @@ $g->set( 'y_label2'     => 'y label 2' );
 $g->set( 'y_grid_lines' => 'true' );
 $g->set( 'legend'       => 'right' );
 
-$g->png("samples/lines_3.png");
+$g->png("$samples/lines_3.png");
 
 print "ok 1\n";
 

--- a/t/lines_4.t
+++ b/t/lines_4.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Lines;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 my $g;
 
 print "1..1\n";
@@ -30,7 +32,7 @@ $g->set( 'y_label2'     => 'y label 2' );
 $g->set( 'y_grid_lines' => 'true' );
 $g->set( 'legend'       => 'top' );
 
-$g->png("samples/lines_4.png");
+$g->png("$samples/lines_4.png");
 
 print "ok 1\n";
 

--- a/t/lines_5.t
+++ b/t/lines_5.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Lines;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 print "1..1\n";
 
 $g = Chart::Lines->new( 600, 300 );
@@ -41,7 +43,7 @@ $g->add_dataset(@y2_values);
 
 $g->set(%hash);
 
-$g->png("samples/lines_5.png");
+$g->png("$samples/lines_5.png");
 
 sub formatter
 {

--- a/t/lines_6.t
+++ b/t/lines_6.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Lines;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 print "1..1\n";
 
 $g = Chart::Lines->new();
@@ -33,7 +35,7 @@ $g->add_dataset( 7,     -5,    -3,     4,      7 );
 
 $g->set(%hash);
 
-$g->png("samples/lines_6.png");
+$g->png("$samples/lines_6.png");
 
 print "ok 1\n";
 

--- a/t/lines_7.t
+++ b/t/lines_7.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Lines;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 my $g;
 
 print "1..1\n";
@@ -22,7 +24,7 @@ $g->set( 'legend'       => 'bottom' );
 $g->set( 'precision'    => '0' );
 $g->set( 'include_zero' => 'true' );
 
-$g->png("samples/lines_7.png");
+$g->png("$samples/lines_7.png");
 
 print "ok 1\n";
 

--- a/t/lines_8.t
+++ b/t/lines_8.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Lines;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 my $g;
 
 print "1..1\n";
@@ -20,7 +22,7 @@ $g->set( 'include_zero'  => 'true' );
 $g->set( 'stepline'      => 'true' );
 $g->set( 'stepline_mode' => 'begin' );
 
-$g->png("samples/lines_8.png");
+$g->png("$samples/lines_8.png");
 
 print "ok 1\n";
 

--- a/t/lines_9.t
+++ b/t/lines_9.t
@@ -4,6 +4,8 @@ BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Lines;
 use Chart::LinesPoints;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 my $g;
 
 print "1..1\n";
@@ -20,7 +22,7 @@ $g->set( 'legend'       => 'none' );
 $g->set( 'xy_plot'      => 1 );
 $g->set( 'x_ticks'      => 'vertical' );
 
-$g->png("samples/lines_9.png");
+$g->png("$samples/lines_9.png");
 
 $g = Chart::Lines->new;
 $g->add_dataset( 10, 20, 30, 40,  50,  60 );
@@ -36,7 +38,7 @@ $g->set(
     xlabels => \@labels,
     xrange  => [ 0, 100 ]
 );
-$g->png("samples/lines_9b.png");
+$g->png("$samples/lines_9b.png");
 
 print "ok 1\n";
 

--- a/t/linespoints.t
+++ b/t/linespoints.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::LinesPoints;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -14,7 +16,7 @@ $g->add_dataset( 5,     7,     2,      7,      9 );
 $g->set( 'title'  => 'Lines and Points Chart' );
 $g->set( 'legend' => 'bottom' );
 
-$g->png("samples/linespoints.png");
+$g->png("$samples/linespoints.png");
 
 print "ok 1\n";
 

--- a/t/linespoints_1.t
+++ b/t/linespoints_1.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::LinesPoints;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -22,7 +24,7 @@ $g->set( 'grid_lines'      => 'true' );
 $g->set( 'grey_background' => 'false' );
 $g->set( 'legend'          => 'bottom' );
 
-$g->png("samples/linespoints_1.png");
+$g->png("$samples/linespoints_1.png");
 
 print "ok 1\n";
 

--- a/t/linespoints_2.t
+++ b/t/linespoints_2.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::LinesPoints;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -45,7 +47,7 @@ $g->add_dataset(@data2);
 );
 
 $g->set(%hash);
-$g->png("samples/linespoints_2.png");
+$g->png("$samples/linespoints_2.png");
 print "ok 1\n";
 
 exit(0);

--- a/t/linespoints_3.t
+++ b/t/linespoints_3.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::LinesPoints;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -33,7 +35,7 @@ $g->add_dataset(@data4);
 );
 
 $g->set(%hash);
-$g->png("samples/linespoints_3.png");
+$g->png("$samples/linespoints_3.png");
 
 #just a trick, to let the y scale start at the biggest point:
 #initiate with negativ values, remove the minus sign!

--- a/t/linespoints_4.t
+++ b/t/linespoints_4.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use strict;
 use Chart::LinesPoints;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -41,6 +43,6 @@ $g->set( 'brush_size' => '4' );
 #  $g-> set ('skip_x_ticks' => $skip_x);
 #   $g-> set ('integer_ticks_only' => 'true');
 
-$g->png("samples/linespoints_4.png");
+$g->png("$samples/linespoints_4.png");
 print "ok 1\n\n";
 

--- a/t/linespoints_5.t
+++ b/t/linespoints_5.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use strict;
 use Chart::Composite;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -63,6 +65,6 @@ $g->set( 'brush_size'   => '4' );
 
 # $g-> set ('skip_x_ticks' => $skip_x);
 
-$g->png("samples/linespoints_5.png");
+$g->png("$samples/linespoints_5.png");
 print "ok 1\n\n";
 

--- a/t/linespoints_6.t
+++ b/t/linespoints_6.t
@@ -4,6 +4,8 @@ BEGIN { unshift @INC, 'lib', '../lib'}
 use strict;
 use Chart::LinesPoints;
 use Chart::Lines;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -430,6 +432,6 @@ $g->set( 'pt_size'         => '20' );
 $g->set( 'brush_size'      => '4' );
 $g->set( 'skip_x_ticks'    => '50' );
 
-$g->png("samples/linespoints_6.png");
+$g->png("$samples/linespoints_6.png");
 print "ok 1\n\n";
 

--- a/t/linespoints_7.t
+++ b/t/linespoints_7.t
@@ -4,6 +4,8 @@ BEGIN { unshift @INC, 'lib', '../lib'}
 use strict;
 use Chart::LinesPoints;
 use Chart::Lines;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -37,6 +39,6 @@ $g->set( 'pt_size'         => '10' );
 $g->set( 'brush_size'      => '3' );
 $g->set( 'stepline'        => 'true' );
 
-$g->png("samples/linespoints_7.png");
+$g->png("$samples/linespoints_7.png");
 print "ok 1\n\n";
 

--- a/t/mapbars.t
+++ b/t/mapbars.t
@@ -2,8 +2,10 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use strict;
 use Chart::Bars;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
-my $png_name = 'samples/mapbars.png';
+my $png_name = "$samples/mapbars.png";
 my @legend_keys = ( "Actual ", "Goal" );
 
 my $Graph = new Chart::Bars( 600, 400 );

--- a/t/mapcomp.t
+++ b/t/mapcomp.t
@@ -1,8 +1,10 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use strict;
 use Chart::Composite;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
-my $png_name = 'samples/mapcomp.png';
+my $png_name = "$samples/mapcomp.png";
 my @legend_keys = ( "Actual ", "Goal" );
 
 #

--- a/t/mountain.t
+++ b/t/mountain.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Mountain;
 use File::Spec;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..2\n";
 
@@ -47,7 +49,7 @@ my @opts = (
 
 foreach my $i ( 1 .. @opts - 1 )
 {
-    my $newpath = File::Spec->catfile( File::Spec->curdir, 'samples', "mountain-$i.png" );
+    my $newpath = File::Spec->catfile( $samples, "mountain-$i.png" );
     my $opts    = $opts[$i];
     my $g       = new Chart::Mountain();
     $g->set(%$opts);

--- a/t/mountain_2.t
+++ b/t/mountain_2.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Mountain;
 use File::Spec;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..2\n";
 
@@ -53,7 +55,7 @@ my @opts = (
 
 foreach my $i ( 1 .. @opts - 1 )
 {
-    my $newpath = File::Spec->catfile( File::Spec->curdir, 'samples', "mountain_2-$i.png" );
+    my $newpath = File::Spec->catfile( $samples, "mountain_2-$i.png" );
     my $opts    = $opts[$i];
     my $g       = new Chart::Mountain();
     $g->set(%$opts);

--- a/t/mountain_3.t
+++ b/t/mountain_3.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Mountain;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -76,7 +78,7 @@ $obj->set(
     'grey_background' => 0,
 );
 
-$obj->png( 'samples/mountain_3.png', \@data );
+$obj->png( "$samples/mountain_3.png", \@data );
 
 print "ok 1\n";
 exit(0);

--- a/t/mountain_4.t
+++ b/t/mountain_4.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Mountain;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -48,7 +50,7 @@ $obj->set(
     'title_font'      => ( GD::Font->Giant )
 );
 
-$obj->png( 'samples/mountain_4.png', \@data );
+$obj->png( "$samples/mountain_4.png", \@data );
 
 print "ok 1\n";
 exit(0);

--- a/t/pareto_1.t
+++ b/t/pareto_1.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Pareto;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -31,7 +33,7 @@ $g->add_dataset( 2500, 1000,  250,  700,  100,  610,  20 );
 );
 
 $g->set(%hash);
-$g->png("samples/pareto_1.png");
+$g->png("$samples/pareto_1.png");
 
 print "ok 1\n";
 

--- a/t/pareto_2.t
+++ b/t/pareto_2.t
@@ -1,6 +1,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Pareto;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -37,7 +39,7 @@ $g->add_dataset( 37, 15, 9, 4, 3.5, 2.1, 1.2, 1.5, 6.2, 16 );
 );
 
 $g->set(%hash);
-$g->png("samples/pareto_2.png");
+$g->png("$samples/pareto_2.png");
 
 print "ok 1\n";
 

--- a/t/pareto_3.t
+++ b/t/pareto_3.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Pareto;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -31,7 +33,7 @@ $g->add_dataset( 3000, 1600,  1500, 400,  100,  20,   5 );
 );
 
 $g->set(%hash);
-$g->png("samples/pareto_3.png");
+$g->png("$samples/pareto_3.png");
 
 print "ok 1\n";
 

--- a/t/pie_1.t
+++ b/t/pie_1.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Pie;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -29,7 +31,7 @@ $g->set(
 );
 $g->set( 'legend_lines' => 'true' );
 
-$g->png("samples/pie_1.png");
+$g->png("$samples/pie_1.png");
 print "ok 1\n";
 
 exit(0);

--- a/t/pie_10.t
+++ b/t/pie_10.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Pie;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -36,7 +38,7 @@ $g->set( 'legend'              => 'right' );
 $g->set( 'grey_background'     => 'false' );
 $g->set( 'legend_lines'        => 'true' );
 
-$g->png("samples/pie_10.png");
+$g->png("$samples/pie_10.png");
 print "ok 1\n";
 
 exit(0);

--- a/t/pie_11.t
+++ b/t/pie_11.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Pie;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -17,7 +19,7 @@ $g->set( 'legend'              => 'bottom' );
 $g->set( 'grey_background'     => 'true' );
 $g->set( 'legend_lines'        => 'true' );
 
-$g->png("samples/pie_11.png");
+$g->png("$samples/pie_11.png");
 print "ok 1\n";
 
 exit(0);

--- a/t/pie_2.t
+++ b/t/pie_2.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Pie;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 my $g;
 
 print "1..1\n";
@@ -19,7 +21,7 @@ $g->set( 'grey_background'     => 'false' );
 $g->set( 'colors'              => { 'title' => 'red' } );
 $g->set( 'legend_lines'        => 'true' );
 
-$g->png("samples/pie_2.png");
+$g->png("$samples/pie_2.png");
 print "ok 1\n";
 
 exit(0);

--- a/t/pie_3.t
+++ b/t/pie_3.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Pie;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -33,7 +35,7 @@ $g->add_dataset( 12000, 20000, 13000, 15000, 9000,  11000 );
 
 $g->set(%opt);
 
-$g->png("samples/pie_3.png");
+$g->png("$samples/pie_3.png");
 
 print "ok 1\n";
 exit(0);

--- a/t/pie_4.t
+++ b/t/pie_4.t
@@ -4,6 +4,8 @@ BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Pie;
 use GD;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -22,7 +24,7 @@ $g->set( 'legend_font'         => gdSmallFont );
 $g->set( 'title_font'          => gdGiantFont );
 $g->set( 'legend_lines'        => 'false' );
 
-$g->png("samples/pie_4.png");
+$g->png("$samples/pie_4.png");
 print "ok 1\n";
 
 exit(0);

--- a/t/pie_5.t
+++ b/t/pie_5.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Pie;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -26,7 +28,7 @@ $g->set(
     }
 );
 
-$g->png("samples/pie_5.png");
+$g->png("$samples/pie_5.png");
 print "ok 1\n";
 
 exit(0);

--- a/t/pie_6.t
+++ b/t/pie_6.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Pie;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -25,7 +27,7 @@ $g->add_dataset( 90,     0,          1,             216,      0 );
 
 $g->set(%opt);
 
-$g->png("samples/pie_6.png");
+$g->png("$samples/pie_6.png");
 
 print "ok 1\n";
 exit(0);

--- a/t/pie_7.t
+++ b/t/pie_7.t
@@ -4,6 +4,8 @@ BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Pie;
 use GD;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -20,7 +22,7 @@ $g->set( 'x_label'             => '' );
 $g->set( 'ring'                => 0.1 );
 $g->set( 'colors'              => { 'background' => 'grey' } );
 
-$g->png("samples/pie_7.png");
+$g->png("$samples/pie_7.png");
 print "ok 1\n";
 
 exit(0);

--- a/t/pie_8.t
+++ b/t/pie_8.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Pie;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -28,7 +30,7 @@ $g->set(
     }
 );
 
-$g->png("samples/pie_8.png");
+$g->png("$samples/pie_8.png");
 print "ok 1\n";
 
 exit(0);

--- a/t/pie_9.t
+++ b/t/pie_9.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Pie;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -18,7 +20,7 @@ $g->set( 'legend'              => 'bottom' );
 $g->set( 'grey_background'     => 'false' );
 $g->set( 'legend_lines'        => 'false' );
 
-$g->png("samples/pie_9.png");
+$g->png("$samples/pie_9.png");
 print "ok 1\n";
 
 exit(0);

--- a/t/points.t
+++ b/t/points.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Points;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -22,7 +24,7 @@ $g->add_dataset( 3,     4,     9 );
 $g->add_dataset( 8, 6, 0 );
 $g->add_dataset( 5, 7, 2 );
 
-$g->png("samples/points.png");
+$g->png("$samples/points.png");
 
 print "ok 1\n";
 

--- a/t/points_100.t
+++ b/t/points_100.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Points;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 my $g;
@@ -25,7 +27,7 @@ $g->set( 'title'        => 'Points Chart with 100 Points' );
 $g->set( 'skip_x_ticks' => 10 );
 
 #$g->set ('skip_int_ticks'=> 10);
-$g->png("samples/points_100.png");
+$g->png("$samples/points_100.png");
 
 print "ok 1\n";
 

--- a/t/points_2.t
+++ b/t/points_2.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Points;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -27,7 +29,7 @@ $g->add_dataset( 0,    0,    0,    0,    0,    0,    0 );
 
 $g->set(@hash);
 
-$g->png("samples/points_2.png");
+$g->png("$samples/points_2.png");
 
 print "ok 1\n";
 

--- a/t/points_3.t
+++ b/t/points_3.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Points;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -24,7 +26,7 @@ $g->add_dataset( -3, 0, 8, 4,  2,  1,  0 );
 
 $g->set(@hash);
 
-$g->png("samples/points_3.png");
+$g->png("$samples/points_3.png");
 
 print "ok 1\n";
 

--- a/t/points_4.t
+++ b/t/points_4.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Points;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -44,7 +46,7 @@ $g->add_dataset( 3,     4,     9 );
 $g->add_dataset( 8, 6, 0 );
 $g->add_dataset( 5, 7, 2 );
 
-$g->png("samples/points_4.png");
+$g->png("$samples/points_4.png");
 
 print "ok 1\n";
 

--- a/t/points_5.t
+++ b/t/points_5.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Points;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -72,7 +74,7 @@ $g->add_dataset( 14,    14,    14 );
 
 $g->set( 'legend_labels' => \@labels );
 
-$g->png("samples/points_5.png");
+$g->png("$samples/points_5.png");
 
 print "ok 1\n";
 

--- a/t/scalarImage.t
+++ b/t/scalarImage.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Lines;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 # bytewise comparision of scalar
 sub imgCompare
@@ -66,7 +68,7 @@ $g->set( 'y_label2'     => 'y label 2' );
 $g->set( 'y_grid_lines' => 'true' );
 $g->set( 'legend'       => 'bottom' );
 
-my $FileName = "samples/scalarImage.png";
+my $FileName = "$samples/scalarImage.png";
 $g->png($FileName);
 
 my $dataref     = $g->get_data();

--- a/t/split_1.t
+++ b/t/split_1.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Split;
 use strict;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 print "1..1\n";
 
 my ( $x, $y, @x, @y, %hash );
@@ -32,7 +34,7 @@ $g->add_dataset(@y);
 );
 $g->set(%hash);
 
-$g->png("samples/split_1.png");
+$g->png("$samples/split_1.png");
 print "ok 1\n";
 
 exit(0);

--- a/t/split_2.t
+++ b/t/split_2.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::Split;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 print "1..1\n";
 
 $g = Chart::Split->new( 500, 500 );
@@ -33,7 +35,7 @@ $g->add_dataset(@y2);
     'legend'         => 'bottom',
 );
 $g->set(%options);
-$g->png("samples/split_2.png");
+$g->png("$samples/split_2.png");
 print "ok 1\n";
 
 exit(0);

--- a/t/stackedbars.t
+++ b/t/stackedbars.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::StackedBars;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -17,7 +19,7 @@ $g->set(
     'grey_background' => 'false',
 );
 
-$g->png("samples/stackedbars.png");
+$g->png("$samples/stackedbars.png");
 
 print "ok 1\n";
 

--- a/t/stackedbars_2.t
+++ b/t/stackedbars_2.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use strict;
 use Chart::StackedBars;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -47,7 +49,7 @@ $g->set(
     }
 );
 
-$g->png("samples/stackedbars_2.png");
+$g->png("$samples/stackedbars_2.png");
 
 print "ok 1\n";
 

--- a/t/stackedbars_3.t
+++ b/t/stackedbars_3.t
@@ -3,6 +3,8 @@
 BEGIN { unshift @INC, 'lib', '../lib'}
 use strict;
 use Chart::StackedBars;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -36,7 +38,7 @@ $g->set(
     }
 );
 
-$g->png("samples/stackedbars_3.png");
+$g->png("$samples/stackedbars_3.png");
 
 print "ok 1\n";
 

--- a/t/stackedbars_4.t
+++ b/t/stackedbars_4.t
@@ -2,6 +2,8 @@
 
 BEGIN { unshift @INC, 'lib', '../lib'}
 use Chart::StackedBars;
+use File::Temp 0.19;
+my $samples = File::Temp->newdir();
 
 print "1..1\n";
 
@@ -43,7 +45,7 @@ $g->set(
     }
 );
 
-$g->png("samples/stackedbars_4.png");
+$g->png("$samples/stackedbars_4.png");
 
 print "ok 1\n";
 


### PR DESCRIPTION
The tests wrote to ./samples directory. This prevent from runnig the
tests from a read-only location:

    $ perl t/bars.t
    1..1
    Error: File "samples/bars.png" could not be created!
     at t/bars.t line 47.

This patch fixes it by using an in-core File::Temp module to create
a temporary directory. The module smart enough to locate a writable
place and to clean up when exiting.