### PR TITLE
Fix typos in Chart::Color::Scheme

### DIFF
--- a/lib/Chart/Color/Scheme.pm
+++ b/lib/Chart/Color/Scheme.pm
@@ -5,7 +5,7 @@ use v5.12;
 
 package Chart::Color::Scheme;
 
-use use Chart::Color::Named;
+use Chart::Color::Named;
 
 my %keys = ( background   => '',
              misc         => '',
@@ -74,17 +74,19 @@ my %scheme = (
 
 
 
-sub all_names  { keys %set }
-sub name_taken { exists  %set{$_[0]} }
+sub all_names  { keys %scheme }
+sub name_taken { exists  $scheme{$_[0]} }
 
 sub add {
     my $name = shift;
     my $my_scheme  = shift;
     return "Color scheme name missing" unless defined $name and $name;
     return "Color scheme already exists" if exists $scheme{$name};
-    return "Color scheme has to be a Hash" if ref $val ne 'HASH';
-    for my $k (keys %$val){
-        return "$k is not a valid key of an color set" unless exists $scheme{'default'}{$k}
+    return "Color scheme has to be a Hash" if ref $my_scheme ne 'HASH';
+    my $my_set = {};
+    for my $k (keys %$my_scheme){
+        return "$k is not a valid key of an color set" unless exists $scheme{'default'}{$k};
+        $my_set->{$k} = $my_scheme->{$k};
     }
     for my $k (keys %{$scheme{'default'}}){
         $my_set->{$k} = $scheme{'default'}{$k} unless exists $my_scheme->{$k};
@@ -92,8 +94,8 @@ sub add {
 
 ## check all color, whole data set
 #    return "Need a Color value (ArrayRef to 3 Int < 256)" if ref $val ne 'ARRAY' or @$val != 3;
-    my $ret = Color->new(@$val);
-    return $ret unless ref $ret;
+#    my $ret = Color->new(@$val);
+#    return $ret unless ref $ret;
     $scheme{$name} = $my_set;
 }
 


### PR DESCRIPTION
lib/Chart/Color/Scheme.pm contained:

    use use Chart::Color::Named;
    [...]
    sub name_taken { exists  %set{$_[0]} }

That prevented from compiling that code:

    $ perl -Ilib -c lib/Chart/Color/Scheme.pm
    Bareword "Chart::Color::Named" not allowed while "strict subs" in use at lib/Chart/Color/Scheme.pm line 8.
    Global symbol "%set" requires explicit package name (did you forget to declare "my %set"?) at lib/Chart/Color/Scheme.pm line 77.
    Global symbol "%set" requires explicit package name (did you forget to declare "my %set"?) at lib/Chart/Color/Scheme.pm line 78.
    exists argument is not a HASH or ARRAY element or a subroutine at lib/Chart/Color/Scheme.pm line 78.

I guess it's a typo and the author did not mean using a "use" module
<https://metacpan.org/pod/use>. Regarding %set, I guess it should be
%scheme based on a similar code in Chart::Color::Named.

Another issue is with $my_set and $val:

    $ perl -Ilib -e 'use Chart::Color::Scheme'
    Global symbol "$val" requires explicit package name (did you forget to declare "my $val"?) at lib/Chart/Color/Scheme.pm line 85.
    Global symbol "$val" requires explicit package name (did you forget to declare "my $val"?) at lib/Chart/Color/Scheme.pm line 86.
    Global symbol "$my_set" requires explicit package name (did you forget to declare "my $my_set"?) at lib/Chart/Color/Scheme.pm line 90.
    Global symbol "$val" requires explicit package name (did you forget to declare "my $val"?) at lib/Chart/Color/Scheme.pm line 95.
    Global symbol "$my_set" requires explicit package name (did you forget to declare "my $my_set"?) at lib/Chart/Color/Scheme.pm line 97.
    Compilation failed in require at -e line 1.

This code looks unfinished. I simplified it to compile and do at least
something.